### PR TITLE
chore: remove phantom submodule and ignore Claude worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,8 @@ bundle-stats*.html
 
 # Claude Code local settings (personal permissions/preferences — not team config)
 .claude/settings.local.json
+# Claude Code agent worktrees (temporary, created per-agent run)
+.claude/worktrees/
 
 # dotenv environment variables file
 .env.local


### PR DESCRIPTION
.claude/worktrees/agent-a72be5fb was accidentally tracked as a gitlink (mode 160000) when Claude Code created an agent worktree there. This caused CI to fail with "No url found for submodule path" during git submodule cleanup steps.

Removes the phantom entry and adds .claude/worktrees/ to .gitignore so future agent worktrees can't be tracked.